### PR TITLE
Alerts: in-chat alert spam protection

### DIFF
--- a/plugins/alerts/alerts.js
+++ b/plugins/alerts/alerts.js
@@ -222,6 +222,13 @@ module.exports = {
             
             var userTest = true;
 
+            perviousSpellCaster = read4File("lates-spell.txt")
+            currentSpellCaster = data.user;
+            write2File("latest-spell.txt", data.user);
+
+            if (perviousSpellCaster == currentSpellCaster) {
+                userTest = false;
+            }
 
 
             // Check if the spell is same as pervious spell
@@ -239,7 +246,7 @@ module.exports = {
             }
 
             Bot.log("activating");
-            write2File("latest-spell.txt", data.user);
+
             const spellSettings = JSON.parse(fs.readFileSync(path.join(__dirname, 'spells.json'), "utf8"));
             var scene = "";
             var source = "";
@@ -294,7 +301,10 @@ module.exports = {
             }));
             obsToggle(scene, source, delay);
             slobsToggle(source, delay);
-            https("spell", data.user, httpMessage);
+
+            if (timeTest && userTest && sameSpellTest) {
+                https("spell", data.user, httpMessage);
+            }
         }
     },
     activate() {

--- a/plugins/alerts/alerts.js
+++ b/plugins/alerts/alerts.js
@@ -233,10 +233,10 @@ module.exports = {
 
             // Check if the spell is same as pervious spell
 
-            var sameSpellTest = true;
+            var sameSpellTest = settings.alerts.spell.seperateSpells;
 
-            if(settings.alerts.spell.seperateSpells && settings.alerts.spell.spellChatSpamProtectFilterSeparateSpells) {
-                var lastSpellName = read4File("latest-spell-name");
+            if(settings.alerts.spell.spellChatSpamProtectFilterSeparateSpells) {
+                var lastSpellName = read4File("latest-spell-name.txt");
                 var currentSpellName = data['content'].name;
                 write2File("latest-spell-name.txt", currentSpellName);
 
@@ -302,7 +302,9 @@ module.exports = {
             obsToggle(scene, source, delay);
             slobsToggle(source, delay);
 
-            if (timeTest && userTest && sameSpellTest) {
+            // Only don't send chat alert if the same user is sending tons of same spell within the timeDelay time limit
+
+            if (timeTest || userTest || sameSpellTest) {
                 https("spell", data.user, httpMessage);
             }
         }

--- a/plugins/alerts/alerts.js
+++ b/plugins/alerts/alerts.js
@@ -209,7 +209,7 @@ module.exports = {
 
                 var d = new Date();
                 var perviousSpellTime = Number(read4File("latest-spell-time.txt"));
-                var currentSpellTime = Number((d.getHours * 60) + d.getMinutes);
+                var currentSpellTime = Number((d.getHours() * 60) + d.getMinutes());
 
                 write2File("latest-spell-time.txt", currentSpellTime);
 

--- a/plugins/alerts/alerts.json
+++ b/plugins/alerts/alerts.json
@@ -27,7 +27,7 @@
       "message": "Thank you {{user}} for the Spells!",
       "spellChatSpamProtect": true,
       "spellChatSpamProtectFilterSeparateSpells": true,
-      "spellChatSpamDelay": 5,
+      "spellChatSpamDelay": 2,
       "httpMessage": "has cast a spell!"
     },
     "joined": {

--- a/plugins/alerts/alerts.json
+++ b/plugins/alerts/alerts.json
@@ -25,6 +25,9 @@
       "source": "SPELL",
       "delay": 5,
       "message": "Thank you {{user}} for the Spells!",
+      "spellChatSpamProtect": true,
+      "spellChatSpamProtectFilterSeparateSpells": true,
+      "spellChatSpamDelay": 5,
       "httpMessage": "has cast a spell!"
     },
     "joined": {


### PR DESCRIPTION
Hello, I've managed to learn how these pull requests work, so here's one.
I've implemented a spam protection feature, which would prevent the bot from spamming alerts into the chat every time a user spams the cheap spells.

- First, we check if the user had already sent a spell within the delay time specified in the config file.
- Second, we check if the pervious spell caster is the current spell caster
- Third, if the user enabled the separateSpells, we check if the user is spamming the same spell.

If the time, user, and spell tests fail, we don't send the chat alert.
If any test passes, we sent the chat alert.

My implementation did work before the present BlazeBot login errors.